### PR TITLE
[SNMP] Update description in entPhysicalDescr mib.

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc2737.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2737.py
@@ -157,9 +157,12 @@ def get_transceiver_description(sfp_type, if_alias):
     :param if_alias: Port alias name
     :return: Transceiver decsription
     """
+    if not if_alias:
+        description = "{}".format(sfp_type)
+    else:
+        description = "{} for {}".format(sfp_type, if_alias)
 
-    return "{} for {}".format(sfp_type, if_alias)
-
+    return description
 
 def get_transceiver_sensor_description(name, lane_number, if_alias):
     """

--- a/tests/mock_tables/state_db.json
+++ b/tests/mock_tables/state_db.json
@@ -40,6 +40,14 @@
     "model": "MODEL_NAME",
     "is_replaceable": "True"
   },
+  "TRANSCEIVER_INFO|Ethernet1": {
+    "type": "QSFP-DD",
+    "hardware_rev": "A1",
+    "serial": "SERIAL_NUM",
+    "manufacturer": "VENDOR_NAME",
+    "model": "MODEL_NAME",
+    "is_replaceable": "True"
+  },
   "TRANSCEIVER_DOM_SENSOR|Ethernet0": {
     "temperature": 25.39,
     "voltage": 3.37,

--- a/tests/test_sn.py
+++ b/tests/test_sn.py
@@ -204,6 +204,26 @@ class TestSonicMIB(TestCase):
 
         self._check_getpdu(sub_id, expected_mib)
 
+    def test_getpdu_xcvr_info_port_disable(self):
+        sub_id = get_transceiver_sub_id(2)[0]
+
+        expected_mib = {
+            2: (ValueType.OCTET_STRING, "QSFP-DD"),
+            4: (ValueType.INTEGER, CHASSIS_SUB_ID),
+            5: (ValueType.INTEGER, PhysicalClass.PORT),
+            6: (ValueType.INTEGER, -1),
+            7: (ValueType.OCTET_STRING, "Ethernet1"),
+            8: (ValueType.OCTET_STRING, "A1"),
+            9: (ValueType.OCTET_STRING, ""), # skip
+            10: (ValueType.OCTET_STRING, ""), # skip
+            11: (ValueType.OCTET_STRING, "SERIAL_NUM"),
+            12: (ValueType.OCTET_STRING, "VENDOR_NAME"),
+            13: (ValueType.OCTET_STRING, "MODEL_NAME"),
+            16: (ValueType.INTEGER, 1)
+        }
+
+        self._check_getpdu(sub_id, expected_mib)
+
     def test_getpdu_xcvr_dom(self):
         expected_mib = {
             get_transceiver_sensor_sub_id(1, SENSOR_TYPE_TEMP)[0]: "DOM Temperature Sensor for etp1",


### PR DESCRIPTION
If a physical cage has a transceiver inserted but there is no ASIC port mapped to this cage, show only transceiver info (without port alias).

Signed-off-by: liora <liora@nvidia.com>

<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**
Update the description to show only transceiver info (instead of transceiver info + port alias) if there is no port mapped to this cage.

**- How I did it**
Update description string in entPhysicalDescr handler.

**- How to verify it**
snmpwalk -v 2c -c public 10.210.24.85 1.3.6.1.2.1.47.1.1.1.1.2 | grep SFP

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

