### PR TITLE
[snmp] Allow system with no ports in config db run without errors

### DIFF
--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -184,7 +184,7 @@ class LocPortUpdater(MIBUpdater):
             self.if_range.append((if_oid, ))
         self.if_range.sort()
         if not self.loc_port_data:
-            logger.warning("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
+            logger.info("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
 
     def _get_if_entry(self, if_name):
         if_table = ""


### PR DESCRIPTION
**What I did**
Allow system with no ports in config db run without errors.
This is needed for modular system which should boot properly without line cards.

**How I did it**
Remove snmpagent error exit if there are no ports in config DB or in counters DB.

**How to verify it**
Run snmpwalk on the root oid.
