### PR TITLE
[snmp] Allow system with no ports in config db run without errors

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -269,7 +269,7 @@ def init_sync_d_interface_tables(db_conn):
 
     # SyncD consistency checks.
     if not oid_name_map:
-        logger.info("Config DB does not contain ports")
+        logger.debug("There are no ports in counters DB")
         return {}, {}, {}, {}
     elif len(if_id_map) < len(if_name_map) or len(oid_name_map) < len(if_name_map):
         # a length mismatch indicates a bad interface name

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -184,7 +184,7 @@ class LocPortUpdater(MIBUpdater):
             self.if_range.append((if_oid, ))
         self.if_range.sort()
         if not self.loc_port_data:
-            logger.info("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
+            logger.debug("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
 
     def _get_if_entry(self, if_name):
         if_table = ""

--- a/src/sonic_ax_impl/mibs/ieee802_1ab.py
+++ b/src/sonic_ax_impl/mibs/ieee802_1ab.py
@@ -184,7 +184,7 @@ class LocPortUpdater(MIBUpdater):
             self.if_range.append((if_oid, ))
         self.if_range.sort()
         if not self.loc_port_data:
-            logger.warning("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
+            logger.info("0 - b'PORT_TABLE' is empty. No local port information could be retrieved.")
 
     def _get_if_entry(self, if_name):
         if_table = ""


### PR DESCRIPTION
**What I did**
Allow system with no ports in config db run without errors.
This is needed for modular system which should boot properly without line cards.

**How I did it**
Remove snmpagent error exit if there are no ports in config DB or in counters DB.

**How to verify it**
Run snmpwalk on the root oid.
